### PR TITLE
Fix shadow DOM attachment for HTML elements

### DIFF
--- a/src/MDXEditor.tsx
+++ b/src/MDXEditor.tsx
@@ -177,7 +177,12 @@ const EditorRootElement: React.FC<{
       styles.popupContainer,
       ...(className ?? '').trim().split(' ').filter(Boolean)
     )
-    document.body.appendChild(popupContainer)
+    const rootNode = editorRootElementRef.current?.getRootNode() as ShadowRoot | Document
+    if (rootNode instanceof ShadowRoot) {
+      rootNode.appendChild(popupContainer)
+    } else {
+      document.body.appendChild(popupContainer)
+    }
     editorRootElementRef.current = popupContainer
     setEditorRootElementRef(editorRootElementRef)
     return () => {

--- a/src/plugins/core/ui/PopoverUtils.tsx
+++ b/src/plugins/core/ui/PopoverUtils.tsx
@@ -6,7 +6,8 @@ import { useCellValue } from '@mdxeditor/gurx'
 
 export const PopoverPortal = (props: RadixPopover.PopoverPortalProps) => {
   const editorRootElementRef = useCellValue(editorRootElementRef$)
-  return <RadixPopover.Portal {...props} container={editorRootElementRef?.current} />
+  const rootNode = editorRootElementRef?.current?.getRootNode() as ShadowRoot | Document
+  return <RadixPopover.Portal {...props} container={rootNode instanceof ShadowRoot ? rootNode : undefined} />
 }
 
 export const PopoverContent = React.forwardRef<any, React.ComponentProps<typeof RadixPopover.Content>>(

--- a/src/plugins/diff-source/DiffViewer.tsx
+++ b/src/plugins/diff-source/DiffViewer.tsx
@@ -54,6 +54,8 @@ export const DiffViewer: React.FC = () => {
           revertControls: 'a-to-b'
         } as const)
 
+    const rootNode = elRef.current?.getRootNode() as ShadowRoot | Document
+
     cmMergeViewRef.current = new MergeView({
       ...revertParams,
       parent: elRef.current!,
@@ -80,7 +82,8 @@ export const DiffViewer: React.FC = () => {
             return null
           })
         ]
-      }
+      },
+      root: rootNode instanceof ShadowRoot ? rootNode : undefined
     })
     return () => {
       cmMergeViewRef.current?.destroy()


### PR DESCRIPTION
Modify components to check for shadow DOM before attaching elements to the document body.

* **`src/MDXEditor.tsx`**
  - Modify `EditorRootElement` component to check if the root node of the editor is in a shadow DOM before appending a `div` element.

* **`src/plugins/core/ui/PopoverUtils.tsx`**
  - Modify `PopoverPortal` component to check if the root node of the editor is in a shadow DOM before attaching a `RadixPopover.Portal`.

* **`src/plugins/diff-source/DiffViewer.tsx`**
  - Modify `DiffViewer` component to check if the root node of the editor is in a shadow DOM before appending a `div` element.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/glenntws/mdx-editor/pull/1?shareId=4a488109-04d5-4a6d-a026-373e1ea343c9).